### PR TITLE
CRUD completo de utilizadores e ajuste no frontend para remoção segura

### DIFF
--- a/AtivosFinanceiros/Controllers/AdminController.cs
+++ b/AtivosFinanceiros/Controllers/AdminController.cs
@@ -1,46 +1,127 @@
-using AtivosFinanceiros.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using AtivosFinanceiros.Models;
+using Microsoft.Extensions.Logging;
 using System.Linq;
+using AtivosFinanceiros.Services;
+using Microsoft.AspNetCore.Cryptography.KeyDerivation;
+using Microsoft.EntityFrameworkCore;
+using System;
 
 namespace AtivosFinanceiros.Controllers
 {
-    [Authorize]
+    [Authorize(Policy = "AdministradorPolicy")]  // conforme suas views
     public class AdminController : Controller
     {
         private readonly MeuDbContext _context;
+        private readonly ILogger<AdminController> _logger;
+        private readonly AuthService _authService;
 
-        public AdminController(MeuDbContext context)
+        public AdminController(ILogger<AdminController> logger, MeuDbContext context, AuthService authService)
         {
             _context = context;
+            _logger = logger;
+            _authService = authService;
         }
 
-        [Authorize(Policy = "AdministradorPolicy")]
+        // GET: /Admin/GerirUtilizadores
         public IActionResult GerirUtilizadores()
         {
             var utilizadores = _context.Usuarios.ToList();
             return View(utilizadores);
         }
-        
-        [Authorize(Policy = "AdministradorPolicy")]
+
+        // GET: /Admin/CriarUtilizador
         public IActionResult CriarUtilizador()
         {
-            return View(); 
+            return View();
         }
 
-        [HttpGet]
-        [Authorize(Policy = "AdministradorPolicy")]
+        // POST: /Admin/CriarUtilizador
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public IActionResult CriarUtilizador(Usuario user)
+        {
+            if (!ModelState.IsValid) return View(user);
+
+            user.UserUuid = Guid.NewGuid();
+            _authService.RegisterUser(user);
+
+            return RedirectToAction(nameof(GerirUtilizadores));
+        }
+
+        // GET: /Admin/EditarUtilizador/{id}
         public IActionResult EditarUtilizador(Guid id)
         {
-            var utilizador = _context.Usuarios.Find(id);
-            if (utilizador == null)
-            {
+            var user = _context.Usuarios.FirstOrDefault(u => u.UserUuid == id);
+            if (user == null)
                 return NotFound();
-            }
 
-            return View(utilizador);
+            return View(user);
         }
 
+        // POST: /Admin/EditarUtilizador
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public IActionResult EditarUtilizador(Usuario user)
+        {
+            ModelState.Remove(nameof(user.Senha));
+        
+            if (!ModelState.IsValid) return View(user);
 
+            var userDb = _context.Usuarios.FirstOrDefault(u => u.UserUuid == user.UserUuid);
+            if (userDb == null) return NotFound();
+
+            userDb.Email = user.Email;
+            userDb.Username = user.Username;
+            userDb.TipoPerfil = user.TipoPerfil;
+
+            if (!string.IsNullOrEmpty(user.Senha))
+            {
+                // Hash da nova senha
+                userDb.Senha = Convert.ToBase64String(KeyDerivation.Pbkdf2(
+                    password: user.Senha,
+                    salt: new byte[0],
+                    prf: KeyDerivationPrf.HMACSHA1,
+                    iterationCount: 10000,
+                    numBytesRequested: 256 / 8));
+            }
+
+            _context.SaveChanges();
+            return RedirectToAction(nameof(GerirUtilizadores));
+        }
+
+        // POST: /Admin/Remover/{id}
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public IActionResult Remover(Guid id)
+        {
+            var user = _context.Usuarios
+                .Include(u => u.Ativos)
+                .ThenInclude(a => a.DepositoPrazos)
+                .Include(u => u.Ativos)
+                .ThenInclude(a => a.FundoInvestimentos)
+                .Include(u => u.Ativos)
+                .ThenInclude(a => a.ImovelArrendados)
+                .FirstOrDefault(u => u.UserUuid == id);
+
+            if (user == null)
+                return NotFound();
+
+            // Remover ativos relacionados
+            foreach (var ativo in user.Ativos)
+            {
+                _context.DepositoPrazos.RemoveRange(ativo.DepositoPrazos);
+                _context.FundoInvestimentos.RemoveRange(ativo.FundoInvestimentos);
+                _context.ImovelArrendados.RemoveRange(ativo.ImovelArrendados);
+            }
+
+            _context.Ativos.RemoveRange(user.Ativos);
+            _context.Usuarios.Remove(user);
+
+            _context.SaveChanges();
+
+            return RedirectToAction(nameof(GerirUtilizadores));
+        }
     }
 }

--- a/AtivosFinanceiros/Views/Admin/GerirUtilizadores.cshtml
+++ b/AtivosFinanceiros/Views/Admin/GerirUtilizadores.cshtml
@@ -1,6 +1,14 @@
+@using System.Security.Claims
+@using Microsoft.AspNetCore.Mvc.TagHelpers
 @model List<AtivosFinanceiros.Models.Usuario>
 @{
     ViewData["Title"] = "Gerir Utilizadores";
+    var currentUserIdString = User.FindFirstValue(ClaimTypes.NameIdentifier);
+    Guid currentUserId = Guid.Empty;
+    if (!string.IsNullOrEmpty(currentUserIdString))
+    {
+        Guid.TryParse(currentUserIdString, out currentUserId);
+    }
 }
 
 <div class="container mt-5 d-flex justify-content-center">
@@ -31,9 +39,12 @@
                         <td>@user.TipoPerfil</td>
                         <td>
                             <a asp-action="EditarUtilizador" asp-route-id="@user.UserUuid" class="btn btn-sm btn-warning mx-1">Editar</a>
-                            <form asp-action="Remover" asp-route-id="@user.UserUuid" method="post" class="d-inline">
-                                <button type="submit" class="btn btn-sm btn-danger" onclick="return confirm('Tem certeza que deseja remover este utilizador?')">Remover</button>
-                            </form>
+                            @if (user.UserUuid != currentUserId)
+                            {
+                                <form asp-action="Remover" asp-route-id="@user.UserUuid" method="post" class="d-inline">
+                                    <button type="submit" class="btn btn-sm btn-danger" onclick="return confirm('Tem certeza que deseja remover este utilizador?')">Remover</button>
+                                </form>
+                            }
                         </td>
                     </tr>
                 }


### PR DESCRIPTION
Implementa o CRUD completo para gestão de utilizadores no backend:
- Criar, editar, listar e remover utilizadores com persistência na base de dados.
- Validação e hash seguro da senha ao criar/editar utilizadores.
- Remoção em cascata dos ativos associados ao utilizador ao eliminar.

No frontend:
- Atualiza a lista de utilizadores para esconder o botão "Remover" no próprio utilizador logado, evitando que este possa eliminar a própria conta.